### PR TITLE
Add the old SF news.

### DIFF
--- a/source/_posts/2008-01-19-what-are-the-differences-between-guliverkli2-and-mpc-hc.md
+++ b/source/_posts/2008-01-19-what-are-the-differences-between-guliverkli2-and-mpc-hc.md
@@ -1,0 +1,11 @@
+---
+author: casimir666
+layout: news
+title: What are the differences between guliverkli2 and mpc-hc?
+---
+
+Gabest, the original author of Media Player Classic, stop working on it by the end of 2006.
+Since then, two forks have been created.
+
+The main differences are that Guliverkli2 contains a few patches made by various people,
+and MPC-HC contains new features. Most patches present in Guliverkli2 are also present in MPC-HC.

--- a/source/_posts/2009-03-16-mpc-hc-will-support-dxva-for-intel-g45.md
+++ b/source/_posts/2009-03-16-mpc-hc-will-support-dxva-for-intel-g45.md
@@ -1,0 +1,10 @@
+---
+author: casimir666
+layout: news
+title: MPC-HC will support DXVA for Intel G45
+---
+
+Good news for Intel G45 users: the next release of MPC-HC will support hardware accelerated
+decoding for H264. Many thanks to Eric and Aaron from Intel Corp for their help and support.
+
+All technical details are in [this](https://software.intel.com/en-us/blogs/2009/03/15/intel-clear-video-and-h264avc/) blog post.

--- a/source/_posts/2009-10-29-tracker-moved-to-trac-and-forum-moved-to-phpb.md
+++ b/source/_posts/2009-10-29-tracker-moved-to-trac-and-forum-moved-to-phpb.md
@@ -1,0 +1,9 @@
+---
+author: tetsuo55
+layout: news
+title: Tracker moved to Trac and forum moved to phpBB
+---
+
+We have moved the tracker and the wiki to [Trac](https://sourceforge.net/apps/trac/mpc-hc/).
+
+We have also migrated to phpBB forum; the old forum has been removed.

--- a/source/_posts/2010-09-07-new-stable-build-released.md
+++ b/source/_posts/2010-09-07-new-stable-build-released.md
@@ -1,0 +1,9 @@
+---
+author: tetsuo55
+layout: news
+title: New stable build released
+---
+
+We have released a new stable build, you can get it from the [downloads page](http://sourceforge.net/projects/mpc-hc/files/).
+
+You can find the changelog [here](http://sourceforge.net/projects/mpc-hc/files/MPC%20HomeCinema%20-%20Win32/MPC-HC%20v1.4.2499.0_32%20bits/Release%20Notes%20v1.4.2499.0.txt/view).

--- a/source/_posts/2010-09-11-contest-for-new-logo-and-explorer-icons.md
+++ b/source/_posts/2010-09-11-contest-for-new-logo-and-explorer-icons.md
@@ -1,0 +1,12 @@
+---
+author: tetsuo55
+layout: news
+title: Contest for new Logo and Explorer Icons
+---
+
+We have opened a thread on Doom9 where users can submit their entries
+for the new logo and explorer icons in MPC-HC.
+
+More information can be found [here](http://forum.doom9.org/showthread.php?p=1433975#post1433975).
+
+Please add your entry!

--- a/source/_posts/2012-04-02-v1614235-released.md
+++ b/source/_posts/2012-04-02-v1614235-released.md
@@ -1,0 +1,19 @@
+---
+author: XhmikosR
+layout: news
+title: v1.6.1.4235 released
+---
+
+We have released a new stable build, you can get it from the [downloads page](http://sourceforge.net/projects/mpc-hc/files/).
+
+You can find the changelog [here](http://sourceforge.net/projects/mpc-hc/files/MPC%20HomeCinema%20-%20Win32/MPC-HC%20v1.6.1.4235_32%20bits/README.txt/view).
+
+We are looking for:
+
+* developers to improve the UI regarding usability and consistency
+* fix bugs
+* improve the renderers part of the player
+* webpage designers for our webpage
+* people who can provide better looking file association icons
+
+If you think you can help MPC-HC drop by #mpc-hc-dev or send an email to me (XhmikosR).

--- a/source/_posts/2012-05-26-v1624902-released.md
+++ b/source/_posts/2012-05-26-v1624902-released.md
@@ -1,0 +1,18 @@
+---
+author: XhmikosR
+layout: news
+title: v1.6.2.4902 released
+---
+
+We have released a new stable build, you can get it from the [downloads page](http://sourceforge.net/projects/mpc-hc/files/).
+
+You can find the changelog [here](http://sourceforge.net/projects/mpc-hc/files/MPC%20HomeCinema%20-%20Win32/MPC-HC_v1.6.2.4902_x86/README.txt/view).
+
+We are looking for:
+
+* developers to improve the UI regarding usability and consistency
+* fix bugs
+* improve the renderers part of the player
+* webpage designers for our webpage
+
+If you think you can help MPC-HC drop by #mpc-hc-dev or send an email to me (XhmikosR).


### PR DESCRIPTION
/CC @mpc-hc/developers 

This is just for historical reasons and in order to remove the news from the SF project page.

Fixes #39.
